### PR TITLE
add reverse proxy mode

### DIFF
--- a/lib/plugins/capture/capture_test.go
+++ b/lib/plugins/capture/capture_test.go
@@ -62,10 +62,10 @@ func newTestResponseWriter() *testResponseWriter {
 }
 
 func TestListenHTTP(t *testing.T) {
-	px = proxy.NewProxy()
+	px = proxy.NewProxy(listenHTTPAddr, "")
 
 	go func(t *testing.T) {
-		if err := px.Start(listenHTTPAddr); err != nil {
+		if err := px.Start(); err != nil {
 			t.Fatal(err)
 		}
 	}(t)

--- a/lib/plugins/logger/logger_test.go
+++ b/lib/plugins/logger/logger_test.go
@@ -61,10 +61,10 @@ func newTestResponseWriter() *testResponseWriter {
 }
 
 func TestListenHTTP(t *testing.T) {
-	px = proxy.NewProxy()
+	px = proxy.NewProxy(listenHTTPAddr, "")
 
 	go func(t *testing.T) {
-		if err := px.Start(listenHTTPAddr); err != nil {
+		if err := px.Start(); err != nil {
 			t.Fatal(err)
 		}
 	}(t)

--- a/lib/proxy/proxy_test.go
+++ b/lib/proxy/proxy_test.go
@@ -125,10 +125,10 @@ func newTestResponseWriter() *testResponseWriter {
 }
 
 func TestListenHTTP(t *testing.T) {
-	proxy = NewProxy()
+	proxy = NewProxy(listenHTTPAddr, "")
 
 	go func(t *testing.T) {
-		if err := proxy.Start(listenHTTPAddr); err != nil {
+		if err := proxy.Start(); err != nil {
 			t.Fatal(err)
 		}
 	}(t)
@@ -137,10 +137,10 @@ func TestListenHTTP(t *testing.T) {
 }
 
 func TestListenHTTPs(t *testing.T) {
-	sslProxy = NewProxy()
+	sslProxy = NewProxy(listenHTTPsAddr, "")
 
 	go func(t *testing.T) {
-		if err := sslProxy.StartTLS(listenHTTPsAddr); err != nil {
+		if err := sslProxy.StartTLS(); err != nil {
 			t.Fatal(err)
 		}
 	}(t)
@@ -182,10 +182,10 @@ func TestUnixServer(t *testing.T) {
 }
 
 func TestListenUnix(t *testing.T) {
-	unixProxy = NewProxy()
+	unixProxy = NewProxy(listenUnixPath, serverUnixPath)
 
 	go func(t *testing.T) {
-		if err := unixProxy.StartUnix(listenUnixPath, serverUnixPath); err != nil {
+		if err := unixProxy.StartUnix(); err != nil {
 			t.Fatal(err)
 		}
 	}(t)


### PR DESCRIPTION
support to run hyperfox as a http/https reverse proxy, thus users don't need to configure arp table and nat to use hyperfox capture packet