### PR TITLE
Fix -dns flag when -https is enabled

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -412,7 +412,9 @@ func (p *Proxy) StartTLS(addr string) error {
 
 	p.srv = srv
 	p.ln = ln
-	p.rt = &http.Transport{}
+	p.rt = &http.Transport{
+		DialContext: p.dialContext,
+	}
 
 	log.Printf("Listening for HTTP requests at %s (SSL/TLS mode)\n", addr)
 	if err := p.srv.Serve(tlsListener); err != nil {


### PR DESCRIPTION
This change makes the `-dns` flag be respected with the `-https` flag

Before this change the `sudo hyperfox -ui -http 80 -dns 8.8.8.8` -> `curl http://example.com` lead to an infinite request loop when `-https` was also supplied (i.e. `sudo hyperfox -ui -http 80 -https 443 -dns 8.8.8.8`).